### PR TITLE
migrate to deno

### DIFF
--- a/.changeset/giant-maps-send.md
+++ b/.changeset/giant-maps-send.md
@@ -1,0 +1,5 @@
+---
+'@ryanatkn/gro': minor
+---
+
+migrate to deno


### PR DESCRIPTION
I saw Deno advertising its Node compatibility as seamless and got excited, but the loader API is not supported and I don't see confirmed plans for it. 

See issues (not linked to avoid backlink spam):

- `https://github.com/denoland/deno/issues/1739`
- `https://github.com/denoland/deno/issues/14842`

I'm a Svelte user and with version 5 there's also `.svelte.ts` files using runes to compile, making the lack of support to appear to be a showstopper.

Gro uses these in its loader:

- https://nodejs.org/api/module.html#resolvespecifier-context-nextresolve
- https://nodejs.org/api/module.html#loadurl-context-nextload

Here:

https://github.com/ryanatkn/gro/blob/64fa4c5c1cf554fdc84772728b0ea764007768c9/src/lib/loader.ts